### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-race.yml
+++ b/.github/workflows/run-race.yml
@@ -13,6 +13,8 @@ jobs:
   run-race:
     name: Run Go Race Detector
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kat1248/go-plh/security/code-scanning/1](https://github.com/kat1248/go-plh/security/code-scanning/1)

In general, the fix is to explicitly add a `permissions` block to the workflow (top level) or to the specific job, granting only the minimal GitHub token permissions required. For this workflow, all steps are read‑only with respect to the repository, so `contents: read` is sufficient and aligns with CodeQL’s suggested minimal starting point.

The best fix without changing existing functionality is to add a job‑level `permissions:` block under `jobs.run-race` (or alternatively a top‑level block). We will modify `.github/workflows/run-race.yml` by inserting:

```yaml
    permissions:
      contents: read
```

immediately under `runs-on: ubuntu-latest` (line 15). No additional imports, methods, or definitions are needed; this is purely a YAML workflow configuration change. All existing steps (checkout, setup-go, cache, go test) will continue to work with read‑only `contents` permissions for `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
